### PR TITLE
Re-implement friend name showing in title of friend page.

### DIFF
--- a/client/journalapp/app/Friend.js
+++ b/client/journalapp/app/Friend.js
@@ -17,7 +17,8 @@ var Friend = (props) => {
       <View style={ styles.row } >
 
 
-        <Text style={ styles.bodyText } onPress={()=>{ props.navigator.push({title: 'FriendPage', friendId: props.id }) }}>
+        <Text style={ styles.bodyText } onPress={()=>{ props.navigator.push({title: 'FriendPage', friendId: props.id });
+                                                       props.updateFriend(props.fullname);}}>
         { props.fullname }
         </Text>
 

--- a/client/journalapp/app/FriendList.js
+++ b/client/journalapp/app/FriendList.js
@@ -16,7 +16,7 @@ var FriendList = (props) => {
     <View>
     <Text style={ styles.subHeader } >Your Friends</Text>
       { props.friendList.map( (friend) => {
-        return ( <Friend username={ friend.username } fullname={ friend.fullname } id={ friend.id } navigator={props.navigator} updateFriend={ props.updateFriend }/> );
+        return ( <Friend username={ friend.username } fullname={ friend.fullname } id={ friend.id } navigator={ props.navigator } updateFriend={ props.updateFriend }/> );
       }) }
 
     </View>

--- a/client/journalapp/app/FriendsTab.js
+++ b/client/journalapp/app/FriendsTab.js
@@ -108,8 +108,8 @@ export default class FriendsTab extends Component {
 
     return (
       <View style= { styles.container } >
-        <RequestList style= {styles.innerContainer} requestList={ this.state.pendingRequests } acceptFriend={this.acceptFriendRequest.bind(this)} navigator={this.props.navigator} />
-        <FriendList style= {styles.innerContainer} friendList={ this.state.friendList } navigator={this.props.navigator} />
+        <RequestList style={styles.innerContainer} requestList={ this.state.pendingRequests } acceptFriend={this.acceptFriendRequest.bind(this)} navigator={this.props.navigator} />
+        <FriendList style={styles.innerContainer} friendList={ this.state.friendList } navigator={this.props.navigator} updateFriend={ this.props.updateFriend }/>
       </View>
     )
   }


### PR DESCRIPTION
This was lost during last merge conflict resolution.
